### PR TITLE
feat(cors): add default Vite port to CORS allowed origins

### DIFF
--- a/src/config/cors.ts
+++ b/src/config/cors.ts
@@ -21,6 +21,7 @@ export const corsOptions: CorsOptions = {
         'https://studio.apollographql.com',
         'http://localhost:4200',
         'https://localhost:3001',
+        'http://localhost:5173',
     ],
     // origin: true,
 


### PR DESCRIPTION
Included 'http://localhost:5173' in the CORS configuration to support Vite development server.